### PR TITLE
Minor fixes

### DIFF
--- a/Semi-Hardcore/src/main/java/com/ftlz/spigot/semihardcore/DeathData.java
+++ b/Semi-Hardcore/src/main/java/com/ftlz/spigot/semihardcore/DeathData.java
@@ -70,4 +70,9 @@ public class DeathData
         int timestamp = (int)(System.currentTimeMillis() / 1000L);
         return _respawnTime > timestamp;
     }
+
+    public void respawningPlayer()
+    {
+        _respawnTime = (int)(System.currentTimeMillis() / 1000L);
+    }
 }

--- a/Semi-Hardcore/src/main/java/com/ftlz/spigot/semihardcore/PlayerMoveListener.java
+++ b/Semi-Hardcore/src/main/java/com/ftlz/spigot/semihardcore/PlayerMoveListener.java
@@ -295,6 +295,10 @@ public class PlayerMoveListener implements Listener
                 fileReader = null;
             }
         }
+        if(_deathLocations == null || !(_deathLocations instanceof HashMap))
+        {
+            _deathLocations = new HashMap<String, DeathData>();
+        }
     }
 
     private void saveData()
@@ -480,7 +484,10 @@ public class PlayerMoveListener implements Listener
         if(player.getGameMode() == GameMode.SPECTATOR)
         {
             player.sendMessage("You're being commanded to rise!");
+            cancelTimer(playerName);
+            _deathLocations.get(player.getName()).respawningPlayer();
             respawnPlayer(player);
+            saveData();
             return true;
         }
         return false;


### PR DESCRIPTION
It is possible, under rare (read broken) circumstances that the deathLocations will be null and not an empty hashmap.
Also, fixed issues where the force player respawn command wasn't correctl updating that players death data. Added a respawningPlayer method to death data to handle any specific requirements internally (for now, it' sjust resetting the respawn time to the current time)